### PR TITLE
return all nlpResult to have all information

### DIFF
--- a/dialogflow-detect-intent.js
+++ b/dialogflow-detect-intent.js
@@ -16,7 +16,7 @@ const makeRequest = (textQuery, sessionPath, languageCode) => ({
 // adds a nlpMetadata object with the already treated message
 const normalizeOutput = msg => nlpResult => ({
   ...msg,
-  payload: nlpResult.fulfillmentText,
+  payload: nlpResult,
   nlpResult
 });
 


### PR DESCRIPTION
it will be better to return response from dialogFlow and not only the text.
The logical  is more abstract, and the develop can use what he wants